### PR TITLE
Fix version conflicts caused by PR#28

### DIFF
--- a/src/BarcodeScanner.Tests/BarcodeScanner.Tests.csproj
+++ b/src/BarcodeScanner.Tests/BarcodeScanner.Tests.csproj
@@ -35,8 +35,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenCvSharp4" Version="4.4.0.20200725" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="OpenCvSharp4" Version="4.5.2.20210404" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0010" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump OpenCvSharp4 from 4.4.0.20200725 to 4.5.2.20210404 in /src. [(PR#28)](https://github.com/colombod/interactiveHackathon/pull/28).
Hope this fix can help you.

Best regards,
sucrose